### PR TITLE
Implement new interface of DatabaseConnection

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -66,6 +66,10 @@ class BunSqliteConnection implements DatabaseConnection {
       rows: stmt.all(parameters as any) as O[],
     })
   }
+
+  async *streamQuery() {
+    throw new Error("Streaming query is not supported by SQLite driver.");
+  }
 }
 
 class ConnectionMutex {


### PR DESCRIPTION
The streamQuery() method is missing for newer versions of kysely.