### PR TITLE
Specify bun as engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "devDependencies": {
     "tsup": "^8.0.1",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "bun": ">=1"
   }
 }


### PR DESCRIPTION
This package will ever only work on bun. I think that justifies specifying bun as a required engine.