### PR TITLE
Make kysely a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "types": "./dist/index.d.ts",
   "dependencies": {
-    "bun-types": "^1.0.25",
+    "bun-types": "^1.0.25"
+  },
+  "peerDependencies": {
     "kysely": "^0.27.2"
   },
   "devDependencies": {


### PR DESCRIPTION
[peerDependencies](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies) are installed by default, so this is not a breaking change. However, it helps with compat if the user has a different version of kysely installed.